### PR TITLE
V0.3.1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,88 @@
+<!--
+Thank you for contributing to this project! You must fill out the information below
+before we can review this pull request.
+
+By explaining why you're making a change (or linking to an issue) and what changes
+you've made, we can triage your pull request to the best possible team for review.
+
+💡 **TIP**
+Remember that you can always open a PR in draft status and fill all the information
+afterwards.
+
+Opening a PR in draft allows other team members to know that you are working on
+this change, and gives you a place to track your work in progress.
+
+When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.
+
+Once you are comfortable with the status of the PR and all the tests and CI is green,
+you can assign the reviewers to start the review process.
+-->
+
+# PR Title
+
+## Summary 💡
+
+<!--
+Write a short summary of the changes that this PR introduces and the motivations
+-->
+
+<!--
+If there's an existing issue for your change, please link to it below inserting a
+link or the issue number.
+
+If there's _not_ an existing issue, please open one first if the problem you are
+solving needs to be clearly identified, for example is an error message that other
+users could get and google it.
+-->
+
+Closes:
+
+<!--
+If this PR is related to changes produced in other repos, like a Module, please
+link them below.
+-->
+
+Relates:
+
+## Description 📝
+
+<!--
+Let us know what you are changing. Share anything that could provide the most context.
+
+Feel free to add screenshots, code examples, the description could end up in the
+release notes to help users adopt the new feature or changes that you are introducing.
+
+Expand on the reasoning behind some decision that you could have made to help reviewers
+understand the diff in the PR.
+-->
+
+## Breaking Changes 💔
+
+<!--
+If this PR introduces Breaking Changes, please include all the relevant information:
+- What is changing
+- What should the process for updating be
+- Include examples if you can
+-->
+
+## Tests performed 🧪
+
+<!--
+Create a checklist with all the tests that you performed on your changes, being
+manual or automated.
+
+If you are opening a Draft PR, you can use the checklist to track the tests that
+you want to do and mark them once you have performed them.
+
+Example:
+
+- [ ] Tested the change with SD version X.Y.Z
+- [ ] Tested an upgrade from the previous version X
+-->
+
+## Future work 🔧
+
+<!--
+If there's any future work that could improve or extend on the work you've done
+in this PR you can mention it so this PR can be used as context for that.
+-->

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Storage Add-On Module
 </h1>
 
-![Release](https://img.shields.io/badge/Latest%20Release-v0.3.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v0.3.1-blue)
 ![License](https://img.shields.io/github/license/sighupio/add-on-storage?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -67,9 +67,9 @@ In your `furyctl.yaml` specify the storage-add-on as a plugin:
 plugins:
   kustomize:
     - name: rook-operator
-      folder: https://github.com/sighupio/add-on-storage/katalog/rook-operator?ref=v0.3.0
+      folder: https://github.com/sighupio/add-on-storage/katalog/rook-operator?ref=v0.3.1
     - name: rook-hostcluster
-      folder: https://github.com/sighupio/add-on-storage/katalog/rook-hostcluster?ref=v0.3.0
+      folder: https://github.com/sighupio/add-on-storage/katalog/rook-hostcluster?ref=v0.3.1
 ```
 
 Then, use `furyctl apply` to deploy cheph in your cluster.
@@ -85,9 +85,9 @@ Then, use `furyctl apply` to deploy cheph in your cluster.
      - name: monitoring/promtheus-operator
        version: "v2.0.1"
      - name: storage/rook-operator
-       version: "v0.3.0"
+       version: "v0.3.1"
      - name: storage/rook-hostcluster
-       version: "v0.3.0"
+       version: "v0.3.1"
    ```
 
    > [!INFO]

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -7,6 +7,7 @@
 | v0.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v0.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v0.3.0                              | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.3.1                              | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ## Rook Operator compatibility against Ceph cluster versions
 
@@ -15,6 +16,7 @@
 | v0.1.0                                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | v0.2.0                                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | v0.3.0                                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.3.1                                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,33 @@
+# Storage Add-On Module Release 0.3.0
+
+Welcome to the latest release of the `storage` add-on module for the [`SIGHUP Distribution`](https://github.com/sighupio/distribution),
+maintained by team SIGHUP.
+
+This release bumps ceph to version `v19.2.2`. The minimum supported Kubernetes version
+is `v1.26.x`.
+
+## Component Images 🚢
+
+| Component       | Supported Version                                              | Previous Version |
+| --------------- | -------------------------------------------------------------- | ---------------- |
+| `rook-operator` | [`v1.15.9`](https://github.com/rook/rook/releases/tag/v1.15.9) | `v1.15.9`        |
+| `ceph`          | [`v19.2.2`](https://github.com/ceph/ceph/releases/tag/v19.2.2) | `v17.2.5`        |
+
+> Please refer to the individual release notes to get a detailed info on the releases.
+
+## Upgrade ⬆️
+
+To upgrade from `v0.3.0` simply apply the new manifests from the respective katalog
+folder:
+
+```sh
+cd katalog/rook-operator
+kustomize build . | kubectl apply -f - --server-side
+cd katalog/rook-hostcluster
+kustomize build . | kubectl apply -f - --server-side
+```
+
+## Deploy 🚀
+
+To deploy this module, please refer to the [deployment section](../../README.md#deployment)
+of the main README.

--- a/katalog/rook-hostcluster/README.md
+++ b/katalog/rook-hostcluster/README.md
@@ -13,7 +13,7 @@ in the following diagram:
 
 > ⚠️ **WARNING**
 > Most probably, you don't want to use this package _as-is_ but you want to choose
-> in which nodes the Ceph cluster will be deployed. Head over to the [example](../../examples/rook-hostcluster-nodeSelector/)
+> in which nodes the Ceph cluster will be deployed. Head over to the [example](../../examples/legacy/rook-hostcluster-nodeSelector/)
 > that shows how to do that.
 
 ## Requirements

--- a/katalog/rook-hostcluster/README.md
+++ b/katalog/rook-hostcluster/README.md
@@ -2,7 +2,7 @@
 
 <!-- <SD-DOCS> -->
 
-Rook Host Cluster deploys a Ceph [host storage cluster](https://rook.io/docs/rook/v1.10/CRDs/Cluster/host-cluster/)
+Rook Host Cluster deploys a Ceph [host storage cluster](https://rook.io/docs/rook/v1.15/CRDs/Cluster/host-cluster/)
 using Rook CRs as defined by [Rook Operator](../rook-operator).
 
 The reference architecture implemented by this module is one with a dedicated node
@@ -18,7 +18,7 @@ in the following diagram:
 
 ## Requirements
 
-- Kubernetes >= `1.19.0`
+- Kubernetes >= `1.26.x`
 - Kustomize = `v3.5.3`
 - [rook-operator](../rook-operator)
 - [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/main/katalog/prometheus-operator)
@@ -26,7 +26,7 @@ in the following diagram:
 
 ## Image repository and tag
 
-- Ceph image: `registry.sighup.io/fury/ceph/ceph:v17.2.5`
+- Ceph image: `registry.sighup.io/fury/ceph/ceph:v19.2.2`
 
 ## Configuration
 

--- a/katalog/rook-hostcluster/README.md
+++ b/katalog/rook-hostcluster/README.md
@@ -2,13 +2,19 @@
 
 <!-- <SD-DOCS> -->
 
-Rook Host Cluster deploys a Ceph [host storage cluster](https://rook.io/docs/rook/v1.10/CRDs/Cluster/host-cluster/) using Rook CRs as defined by [Rook Operator](../rook-operator).
+Rook Host Cluster deploys a Ceph [host storage cluster](https://rook.io/docs/rook/v1.10/CRDs/Cluster/host-cluster/)
+using Rook CRs as defined by [Rook Operator](../rook-operator).
 
-The reference architecture implemented by this module is one with a dedicated node pool with directly attached storage provisioned by a human operator, as summarised in the following diagram:
+The reference architecture implemented by this module is one with a dedicated node
+pool with directly attached storage provisioned by a human operator, as summarised
+in the following diagram:
+
 ![Fury Storage Reference Architecture](../../docs/assets/reference-architecture.png)
 
 > ⚠️ **WARNING**
-> Most probably, you don't want to use this package _as-is_ but you want to choose in which nodes the Ceph cluster will be deployed. Head over to the [example](../../examples/rook-hostcluster-nodeSelector/) that shows how to do that.
+> Most probably, you don't want to use this package _as-is_ but you want to choose
+> in which nodes the Ceph cluster will be deployed. Head over to the [example](../../examples/rook-hostcluster-nodeSelector/)
+> that shows how to do that.
 
 ## Requirements
 
@@ -47,16 +53,19 @@ You can access the Ceph dashboard with your browser by port-forwarding on port 8
 kubectl port-forward svc/rook-ceph-mgr-dashboard 8443:8443 --namespace rook-ceph
 ```
 
-You can retrieve the generated credentials for the `admin` user running the following command:
+You can retrieve the generated credentials for the `admin` user running the following
+command:
 
 ```shell
 kubectl -n rook-ceph get secret rook-ceph-dashboard-password -o jsonpath="{['data']['password']}" | base64 --decode && echo
 ```
 
-Now if you go to <https://127.0.0.1:8443> on your browser you can authenticate and interact with your Ceph cluster.
+Now if you go to <https://127.0.0.1:8443> on your browser you can authenticate and
+interact with your Ceph cluster.
 
 > ⚠️ **WARNING**
-> Be careful since, by default, the dashboard gives you R/W access to your Ceph cluster and you risk of deleting resources created throught the operator CRDs.
+> Be careful since, by default, the dashboard gives you R/W access to your Ceph
+> cluster and you risk of deleting resources created throught the operator CRDs.
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/rook-hostcluster/README.md
+++ b/katalog/rook-hostcluster/README.md
@@ -19,7 +19,7 @@ in the following diagram:
 ## Requirements
 
 - Kubernetes >= `1.26.x`
-- Kustomize = `v3.5.3`
+- Kustomize = `v5.6.0`
 - [rook-operator](../rook-operator)
 - [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/main/katalog/prometheus-operator)
 - Empty raw disks attached to Ceph nodes

--- a/katalog/rook-hostcluster/ceph-cluster.yaml
+++ b/katalog/rook-hostcluster/ceph-cluster.yaml
@@ -25,7 +25,7 @@ spec:
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
     # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v18.2.4-20240724
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: registry.sighup.io/fury/ceph/ceph:v17.2.5
+    image: registry.sighup.io/fury/ceph/ceph:v19.2.2
     # Whether to allow unsupported versions of Ceph. Currently `quincy` and `reef` are supported.
     # Future versions such as `squid` (v19) would require this to be set to `true`.
     # Do not set to true in production.

--- a/katalog/rook-hostcluster/kustomization.yaml
+++ b/katalog/rook-hostcluster/kustomization.yaml
@@ -14,7 +14,7 @@ images:
     newTag: v1.15.9
   - name: quay.io/ceph/ceph
     newName: registry.sighup.io/fury/ceph/ceph
-    newTag: v17.2.5
+    newTag: v19.2.2
 
 resources:
   - monitoring

--- a/katalog/rook-operator/README.md
+++ b/katalog/rook-operator/README.md
@@ -15,7 +15,6 @@ cluster. See [Rook website][rook-website] for more details about the project.
 ## Image repository and tag
 
 - Rook Operator image: `registry.sighup.io/fury/rook/ceph:v1.15.9`
-- Ceph image: `registry.sighup.io/fury/ceph/ceph:v17.2.5`
 
 ## Deployment
 

--- a/katalog/rook-operator/README.md
+++ b/katalog/rook-operator/README.md
@@ -7,7 +7,7 @@ cluster. See [Rook website][rook-website] for more details about the project.
 
 ## Requirements
 
-- Kubernetes >= `1.29.0`
+- Kubernetes >= `1.26.0`
 
 > cert-manager is nedeed to let Rook setup a Validating Webhook to assess that Rook
 > CRDs are correctly configured.


### PR DESCRIPTION
# `v0.3.1`

## Summary 💡

This pull request bumps Ceph to version `v19.2.2`

## Description 📝

This PR does not contain many changes to the project, since most of the manifests depend on `rook` which stays at `v1.15.9`. The next version of the module will bump it to `v1.17`. Before doing so we bump Ceph to its latest version to avoid upgrading two components at the same time which seemed safer since we are dealing with storage, a critical component.

While working at the repo I formatted and linted the markdown files I worked on (this time with a separate, dedicated commit) and I also added a PR template for future PRs. 🌱

## Breaking Changes 💔

This release **does not** contain any breaking changes, the version constraints have been updated according to the deployed Ceph and rook-operator's versions.

## Tests performed 🧪

- [x] Upgrade from `v0.3.0` to `v0.3.1` on SIGHUP Distribution running logging and monitoring on top of ceph. The data was retained and kept coming in after the upgrade.

## Future work 🔧

Release `v0.4.0` with rook `v1.17`