### PR TITLE
V0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Storage Add-On Module
 </h1>
 
-![Release](https://img.shields.io/badge/Latest%20Release-v0.3.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v0.4.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/add-on-storage?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -32,7 +32,7 @@ The following packages are included in the Storage Add-On Module katalog:
 
 | Package                                                                    | Version   | Description                                                                                     |
 | -------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
-| [rook-operator](katalog/rook-operator)                                     | `v1.15.9` | Rook provides a way to run a highly available, durable Ceph storage in your Kubernetes cluster. |
+| [rook-operator](katalog/rook-operator)                                     | `v1.17.2` | Rook provides a way to run a highly available, durable Ceph storage in your Kubernetes cluster. |
 | [rook-hostcluster](katalog/rook-hostcluster)                               | `NA`      | Rook CRDs to run a production ready Ceph cluster providing Block and File storage.              |
 | [nfs-subdir-external-provisioner](katalog/nfs-subdir-external-provisioner) | `v4.0.2`  | Dynamic sub-dir volume provisioner on a remote NFS server.                                      |
 
@@ -40,8 +40,8 @@ Click on each package to see its full documentation.
 
 ## Compatibility
 
-- The minimum supported Kubernetes version is `v1.26.x`.
-- The minimum supported Ceph version is `v17.2.0`
+- The minimum supported Kubernetes version is `v1.28.x`.
+- The minimum supported Ceph version is `v18.2.0`
 
 Check the [compatibility matrix][compatibility-matrix] for additional information
 about previous releases of the module.
@@ -67,9 +67,9 @@ In your `furyctl.yaml` specify the storage-add-on as a plugin:
 plugins:
   kustomize:
     - name: rook-operator
-      folder: https://github.com/sighupio/add-on-storage/katalog/rook-operator?ref=v0.3.1
+      folder: https://github.com/sighupio/add-on-storage/katalog/rook-operator?ref=v0.4.0
     - name: rook-hostcluster
-      folder: https://github.com/sighupio/add-on-storage/katalog/rook-hostcluster?ref=v0.3.1
+      folder: https://github.com/sighupio/add-on-storage/katalog/rook-hostcluster?ref=v0.4.0
 ```
 
 Then, use `furyctl apply` to deploy cheph in your cluster.
@@ -85,9 +85,9 @@ Then, use `furyctl apply` to deploy cheph in your cluster.
      - name: monitoring/promtheus-operator
        version: "v2.0.1"
      - name: storage/rook-operator
-       version: "v0.3.1"
+       version: "v0.4.0"
      - name: storage/rook-hostcluster
-       version: "v0.3.1"
+       version: "v0.4.0"
    ```
 
    > [!INFO]

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -2,12 +2,13 @@
 
 ## Tested Kubernetes versions
 
-| Module Version / Kubernetes Version | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             |
-| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
-| v0.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v0.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v0.3.0                              | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v0.3.1                              | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X             | 1.33.X             |
+| ----------------------------------- | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ | ------------------ |
+| v0.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.3.0                              | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.3.1                              | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.4.0                              | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ## Rook Operator compatibility against Ceph cluster versions
 
@@ -17,6 +18,7 @@
 | v0.2.0                                | :white_check_mark: | :white_check_mark: | :x:                | :x:                |
 | v0.3.0                                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | v0.3.1                                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v0.4.0                                | :x:                | :x:                | :white_check_mark: | :white_check_mark: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,4 +1,4 @@
-# Storage Add-On Module Release 0.3.0
+# Storage Add-On Module Release 0.3.1
 
 Welcome to the latest release of the `storage` add-on module for the [`SIGHUP Distribution`](https://github.com/sighupio/distribution),
 maintained by team SIGHUP.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,33 @@
+# Storage Add-On Module Release 0.4.0
+
+Welcome to the latest release of the `storage` add-on module for the [`SIGHUP Distribution`](https://github.com/sighupio/distribution),
+maintained by team SIGHUP.
+
+This release bumps rook to version `v1.17.2`. The minimum supported Kubernetes version
+is `v1.28.x`.
+
+## Component Images 🚢
+
+| Component       | Supported Version                                              | Previous Version |
+| --------------- | -------------------------------------------------------------- | ---------------- |
+| `rook-operator` | [`v1.17.2`](https://github.com/rook/rook/releases/tag/v1.15.9) | `v1.15.9`        |
+| `ceph`          | [`v19.2.2`](https://github.com/ceph/ceph/releases/tag/v19.2.2) | `v17.2.5`        |
+
+> Please refer to the individual release notes to get a detailed info on the releases.
+
+## Upgrade ⬆️
+
+To upgrade from `v0.3.1` simply apply the new manifests from the respective katalog
+folder:
+
+```sh
+cd katalog/rook-operator
+kustomize build . | kubectl apply -f - --server-side
+cd katalog/rook-hostcluster
+kustomize build . | kubectl apply -f - --server-side
+```
+
+## Deploy 🚀
+
+To deploy this module, please refer to the [deployment section](../../README.md#deployment)
+of the main README.

--- a/katalog/rook-hostcluster/MAINTENANCE.md
+++ b/katalog/rook-hostcluster/MAINTENANCE.md
@@ -3,15 +3,15 @@
 The resources in this package were tailor-made but were based on the following
 files from the upstream project:
 
-- [cluster.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/cluster.yaml)
-- [pool.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/pool.yaml)
-- [rbd/storageclass.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/csi/rbd/storageclass.yaml)
-- [filesystem.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/filesystem.yaml)
-- [cephfs/storageclass.yml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/csi/cephfs/storageclass.yaml)
-- [toolbox.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/toolbox.yaml)
+- [cluster.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/cluster.yaml)
+- [pool.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/pool.yaml)
+- [rbd/storageclass.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/csi/rbd/storageclass.yaml)
+- [filesystem.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/filesystem.yaml)
+- [cephfs/storageclass.yml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/csi/cephfs/storageclass.yaml)
+- [toolbox.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/toolbox.yaml)
 
 For the monitoring folder, refer to
 
-- [rbac.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/monitoring/rbac.yaml)
-- [localrules.yaml](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/monitoring/localrules.yaml)
-- [dashboards](https://github.com/rook/rook/blob/v1.15.9/deploy/examples/monitoring/grafana)
+- [rbac.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/monitoring/rbac.yaml)
+- [localrules.yaml](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/monitoring/localrules.yaml)
+- [dashboards](https://github.com/rook/rook/blob/v1.17.2/deploy/examples/monitoring/grafana)

--- a/katalog/rook-hostcluster/README.md
+++ b/katalog/rook-hostcluster/README.md
@@ -18,7 +18,7 @@ in the following diagram:
 
 ## Requirements
 
-- Kubernetes >= `1.26.x`
+- Kubernetes >= `1.28.x`
 - Kustomize = `v5.6.0`
 - [rook-operator](../rook-operator)
 - [prometheus-operator](https://github.com/sighupio/fury-kubernetes-monitoring/tree/main/katalog/prometheus-operator)
@@ -65,7 +65,7 @@ interact with your Ceph cluster.
 
 > ⚠️ **WARNING**
 > Be careful since, by default, the dashboard gives you R/W access to your Ceph
-> cluster and you risk of deleting resources created throught the operator CRDs.
+> cluster and you risk of deleting resources created through the operator CRDs.
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/rook-hostcluster/ceph-cluster.yaml
+++ b/katalog/rook-hostcluster/ceph-cluster.yaml
@@ -20,14 +20,14 @@ metadata:
 spec:
   cephVersion:
     # The container image used to launch the Ceph daemon pods (mon, mgr, osd, mds, rgw).
-    # v17 is Quincy, v18 is Reef.
-    # RECOMMENDATION: In production, use a specific version tag instead of the general v17 flag, which pulls the latest release and could result in different
+    # v18 is Reef, v19 is Squid
+    # RECOMMENDATION: In production, use a specific version tag instead of the general v19 flag, which pulls the latest release and could result in different
     # versions running within the cluster. See tags available at https://hub.docker.com/r/ceph/ceph/tags/.
-    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v18.2.4-20240724
+    # If you want to be more precise, you can always use a timestamp tag such as quay.io/ceph/ceph:v19.2.2-20250409
     # This tag might not contain a new Ceph version, just security fixes from the underlying operating system, which will reduce vulnerabilities
-    image: registry.sighup.io/fury/ceph/ceph:v19.2.2
-    # Whether to allow unsupported versions of Ceph. Currently `quincy` and `reef` are supported.
-    # Future versions such as `squid` (v19) would require this to be set to `true`.
+    image: quay.io/ceph/ceph:v19.2.2
+    # Whether to allow unsupported versions of Ceph. Currently Reef and Squid are supported.
+    # Future versions such as Tentacle (v20) would require this to be set to `true`.
     # Do not set to true in production.
     allowUnsupported: false
   # The path on the host where configuration files will be persisted. Must be specified. If there are multiple clusters, the directory must be unique for each cluster.
@@ -312,10 +312,6 @@ spec:
     # A duration in minutes that determines how long an entire failureDomain like `region/zone/host` will be held in `noout` (in addition to the
     # default DOWN/OUT interval) when it is draining. This is only relevant when  `managePodBudgets` is `true`. The default value is `30` minutes.
     osdMaintenanceTimeout: 30
-    # A duration in minutes that the operator will wait for the placement groups to become healthy (active+clean) after a drain was completed and OSDs came back up.
-    # Operator will continue with the next drain if the timeout exceeds. It only works if `managePodBudgets` is `true`.
-    # No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
-    pgHealthCheckTimeout: 0
 
   # csi defines CSI Driver settings applied per cluster.
   csi:
@@ -330,7 +326,7 @@ spec:
     cephfs:
       # Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options.
       # kernelMountOptions: ""
-      # Set CephFS Fuse mount options to use https://docs.ceph.com/en/quincy/man/8/ceph-fuse/#options.
+      # Set CephFS Fuse mount options to use https://docs.ceph.com/en/latest/man/8/ceph-fuse/#options.
       # fuseMountOptions: ""
 
   # healthChecks

--- a/katalog/rook-hostcluster/ceph-filesystem.yaml
+++ b/katalog/rook-hostcluster/ceph-filesystem.yaml
@@ -95,8 +95,6 @@ spec:
                     values:
                       - rook-ceph-mds
               # topologyKey: */zone can be used to spread MDS across different AZ
-              # Use <topologyKey: failure-domain.beta.kubernetes.io/zone> in k8s cluster if your cluster is v1.16 or lower
-              # Use <topologyKey: topology.kubernetes.io/zone>  in k8s cluster is v1.17 or upper
               topologyKey: topology.kubernetes.io/zone
     # A key/value list of annotations
     # annotations:

--- a/katalog/rook-hostcluster/kustomization.yaml
+++ b/katalog/rook-hostcluster/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: rook-ceph
 images:
   - name: rook/ceph
     newName: registry.sighup.io/fury/rook/ceph
-    newTag: v1.15.9
+    newTag: v1.17.2
   - name: quay.io/ceph/ceph
     newName: registry.sighup.io/fury/ceph/ceph
     newTag: v19.2.2

--- a/katalog/rook-hostcluster/toolbox.yaml
+++ b/katalog/rook-hostcluster/toolbox.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: rook-ceph-default
       containers:
         - name: rook-ceph-tools
-          image: quay.io/ceph/ceph:v18.2.4
+          image: quay.io/ceph/ceph:v19
           command:
             - /bin/bash
             - -c

--- a/katalog/rook-operator/MAINTENANCE.md
+++ b/katalog/rook-operator/MAINTENANCE.md
@@ -5,7 +5,7 @@ To prepare a new release of this package:
 1. Get the current upstream release
 
    ```bash
-   export ROOK_RELEASE=v1.15.9
+   export ROOK_RELEASE=v1.17.2
    wget -c https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/common.yaml \
      https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/crds.yaml \
      https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/toolbox.yaml \

--- a/katalog/rook-operator/MAINTENANCE.md
+++ b/katalog/rook-operator/MAINTENANCE.md
@@ -8,7 +8,6 @@ To prepare a new release of this package:
    export ROOK_RELEASE=v1.17.2
    wget -c https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/common.yaml \
      https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/crds.yaml \
-     https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/toolbox.yaml \
      https://raw.githubusercontent.com/rook/rook/${ROOK_RELEASE}/deploy/examples/operator.yaml
    ```
 
@@ -18,5 +17,5 @@ To prepare a new release of this package:
    file in `kustomization.yaml`
 3. Update the `kustomization.yaml` file with the new image versions.
 4. Update `rook-ceph-operator-config-csi-images.yml` with the correct images, refer
-   to the [docs](https://rook.io/docs/rook/v1.15/Storage-Configuration/Ceph-CSI/custom-images/)
+   to the [docs](https://rook.io/docs/rook/v1.17/Storage-Configuration/Ceph-CSI/custom-images/)
 5. Sync the new images to our registry in the [container-image-sync repository](https://github.com/sighupio/fury-distribution-container-image-sync/blob/main/modules/storage/images.yml).

--- a/katalog/rook-operator/README.md
+++ b/katalog/rook-operator/README.md
@@ -7,14 +7,14 @@ cluster. See [Rook website][rook-website] for more details about the project.
 
 ## Requirements
 
-- Kubernetes >= `1.26.0`
+- Kubernetes >= `1.28.0`
 
 > cert-manager is nedeed to let Rook setup a Validating Webhook to assess that Rook
 > CRDs are correctly configured.
 
 ## Image repository and tag
 
-- Rook Operator image: `registry.sighup.io/fury/rook/ceph:v1.15.9`
+- Rook Operator image: `registry.sighup.io/fury/rook/ceph:v1.17.2`
 
 ## Deployment
 

--- a/katalog/rook-operator/common.yaml
+++ b/katalog/rook-operator/common.yaml
@@ -76,13 +76,13 @@ rules:
     verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch", "create"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "patch", "update", "create"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
@@ -100,6 +100,9 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
     verbs: ["create"]
 ---
 kind: ClusterRole
@@ -151,6 +154,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -189,13 +195,13 @@ rules:
     verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch", "create"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["get", "list", "watch", "patch", "update", "create"]
+    verbs: ["get", "list", "watch", "patch", "update"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
@@ -220,6 +226,15 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationcontents"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["replication.storage.openshift.io"]
+    resources: ["volumegroupreplicationclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
 ---
 # The cluster role for managing all the cluster-specific resources in a namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -283,6 +298,7 @@ rules:
       - watch
   - apiGroups:
       - ""
+      - "discovery.k8s.io"
     resources:
       # Rook creates events for its custom resources
       - events
@@ -292,6 +308,8 @@ rules:
       # Rook creates endpoints for mgr and object store access
       - endpoints
       - services
+      - endpointslices
+      - endpointslices/restricted
     verbs:
       - get
       - list
@@ -783,7 +801,16 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["create"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -793,7 +820,16 @@ metadata:
 rules:
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["create"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -806,7 +842,16 @@ rules:
     verbs: ["get", "watch", "list", "delete", "update", "create"]
   - apiGroups: ["csiaddons.openshift.io"]
     resources: ["csiaddonsnodes"]
-    verbs: ["create"]
+    verbs: ["get", "watch", "list", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers", "daemonsets/finalizers"]
+    verbs: ["update"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/katalog/rook-operator/crds.yaml
+++ b/katalog/rook-operator/crds.yaml
@@ -67,6 +67,38 @@ spec:
                   x-kubernetes-validations:
                     - message: blockPoolName is immutable
                       rule: self == oldSelf
+                mirroring:
+                  description: Mirroring configuration of CephBlockPoolRadosNamespace
+                  properties:
+                    mode:
+                      description: Mode is the mirroring mode; either pool or image.
+                      enum:
+                        - ""
+                        - pool
+                        - image
+                      type: string
+                    remoteNamespace:
+                      description: RemoteNamespace is the name of the CephBlockPoolRadosNamespace on the secondary cluster CephBlockPool
+                      type: string
+                    snapshotSchedules:
+                      description: SnapshotSchedules is the scheduling of snapshot for mirrored images
+                      items:
+                        description: SnapshotScheduleSpec represents the snapshot scheduling settings of a mirrored pool
+                        properties:
+                          interval:
+                            description: Interval represent the periodicity of the snapshot.
+                            type: string
+                          path:
+                            description: Path is the path to snapshot, only valid for CephFS
+                            type: string
+                          startTime:
+                            description: StartTime indicates when to start the snapshot
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                    - mode
+                  type: object
                 name:
                   description: The name of the CephBlockPoolRadosNamespaceSpec namespace. If not set, the default is the name of the CR.
                   type: string
@@ -79,14 +111,169 @@ spec:
             status:
               description: Status represents the status of a CephBlockPool Rados Namespace
               properties:
+                conditions:
+                  items:
+                    description: Condition represents a status condition on any Rook-Ceph Custom Resource.
+                    properties:
+                      lastHeartbeatTime:
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        description: ConditionReason is a reason for a condition
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ConditionType represent a resource's status
+                        type: string
+                    type: object
+                  type: array
                 info:
                   additionalProperties:
                     type: string
                   nullable: true
                   type: object
+                mirroringInfo:
+                  description: MirroringInfoSpec is the status of the pool/radosnamespace mirroring
+                  properties:
+                    details:
+                      type: string
+                    lastChanged:
+                      type: string
+                    lastChecked:
+                      type: string
+                    mode:
+                      description: Mode is the mirroring mode
+                      type: string
+                    peers:
+                      description: Peers are the list of peer sites connected to that cluster
+                      items:
+                        description: PeersSpec contains peer details
+                        properties:
+                          client_name:
+                            description: ClientName is the CephX user used to connect to the peer
+                            type: string
+                          direction:
+                            description: Direction is the peer mirroring direction
+                            type: string
+                          mirror_uuid:
+                            description: MirrorUUID is the mirror UUID
+                            type: string
+                          site_name:
+                            description: SiteName is the current site name
+                            type: string
+                          uuid:
+                            description: UUID is the peer UUID
+                            type: string
+                        type: object
+                      type: array
+                    site_name:
+                      description: SiteName is the current site name
+                      type: string
+                  type: object
+                mirroringStatus:
+                  description: MirroringStatusSpec is the status of the pool/radosNamespace mirroring
+                  properties:
+                    details:
+                      description: Details contains potential status errors
+                      type: string
+                    lastChanged:
+                      description: LastChanged is the last time time the status last changed
+                      type: string
+                    lastChecked:
+                      description: LastChecked is the last time time the status was checked
+                      type: string
+                    summary:
+                      description: Summary is the mirroring status summary
+                      properties:
+                        daemon_health:
+                          description: DaemonHealth is the health of the mirroring daemon
+                          type: string
+                        health:
+                          description: Health is the mirroring health
+                          type: string
+                        image_health:
+                          description: ImageHealth is the health of the mirrored image
+                          type: string
+                        states:
+                          description: States is the various state for all mirrored images
+                          nullable: true
+                          properties:
+                            error:
+                              description: Error is when the mirroring state is errored
+                              type: integer
+                            replaying:
+                              description: Replaying is when the replay of the mirroring journal is on-going
+                              type: integer
+                            starting_replay:
+                              description: StartingReplay is when the replay of the mirroring journal starts
+                              type: integer
+                            stopped:
+                              description: Stopped is when the mirroring state is stopped
+                              type: integer
+                            stopping_replay:
+                              description: StopReplaying is when the replay of the mirroring journal stops
+                              type: integer
+                            syncing:
+                              description: Syncing is when the image is syncing
+                              type: integer
+                            unknown:
+                              description: Unknown is when the mirroring state is unknown
+                              type: integer
+                          type: object
+                      type: object
+                  type: object
                 phase:
                   description: ConditionType represent a resource's status
                   type: string
+                snapshotScheduleStatus:
+                  description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
+                  properties:
+                    details:
+                      description: Details contains potential status errors
+                      type: string
+                    lastChanged:
+                      description: LastChanged is the last time time the status last changed
+                      type: string
+                    lastChecked:
+                      description: LastChecked is the last time time the status was checked
+                      type: string
+                    snapshotSchedules:
+                      description: SnapshotSchedules is the list of snapshots scheduled
+                      items:
+                        description: SnapshotSchedulesSpec is the list of snapshot scheduled for images in a pool
+                        properties:
+                          image:
+                            description: Image is the mirrored image
+                            type: string
+                          items:
+                            description: Items is the list schedules times for a given snapshot
+                            items:
+                              description: SnapshotSchedule is a schedule
+                              properties:
+                                interval:
+                                  description: Interval is the interval in which snapshots will be taken
+                                  type: string
+                                start_time:
+                                  description: StartTime is the snapshot starting time
+                                  type: string
+                              type: object
+                            type: array
+                          namespace:
+                            description: Namespace is the RADOS namespace the image is part of
+                            type: string
+                          pool:
+                            description: Pool is the pool name
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  type: object
               type: object
               x-kubernetes-preserve-unknown-fields: true
           required:
@@ -229,7 +416,11 @@ spec:
                       description: Enabled whether this pool is mirrored or not
                       type: boolean
                     mode:
-                      description: 'Mode is the mirroring mode: either pool or image'
+                      description: 'Mode is the mirroring mode: pool, image or init-only.'
+                      enum:
+                        - pool
+                        - image
+                        - init-only
                       type: string
                     peers:
                       description: Peers represents the peers spec
@@ -379,7 +570,7 @@ spec:
                   nullable: true
                   type: object
                 mirroringInfo:
-                  description: MirroringInfoSpec is the status of the pool mirroring
+                  description: MirroringInfoSpec is the status of the pool/radosnamespace mirroring
                   properties:
                     details:
                       type: string
@@ -417,7 +608,7 @@ spec:
                       type: string
                   type: object
                 mirroringStatus:
-                  description: MirroringStatusSpec is the status of the pool mirroring
+                  description: MirroringStatusSpec is the status of the pool/radosNamespace mirroring
                   properties:
                     details:
                       description: Details contains potential status errors
@@ -475,6 +666,9 @@ spec:
                 phase:
                   description: ConditionType represent a resource's status
                   type: string
+                poolID:
+                  description: optional
+                  type: integer
                 snapshotScheduleStatus:
                   description: SnapshotScheduleStatusSpec is the status of the snapshot schedule
                   properties:
@@ -796,6 +990,38 @@ spec:
                         disableVerifySSL:
                           description: Indicate whether the server certificate is validated by the client or not
                           type: boolean
+                        mechanism:
+                          default: PLAIN
+                          description: The authentication mechanism for this topic (PLAIN/SCRAM-SHA-512/SCRAM-SHA-256/GSSAPI/OAUTHBEARER)
+                          enum:
+                            - PLAIN
+                            - SCRAM-SHA-512
+                            - SCRAM-SHA-256
+                            - GSSAPI
+                            - OAUTHBEARER
+                          type: string
+                        passwordSecretRef:
+                          description: The kafka password to use for authentication
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
                         uri:
                           description: The URI of the Kafka endpoint to push notification to
                           minLength: 1
@@ -803,6 +1029,28 @@ spec:
                         useSSL:
                           description: Indicate whether to use SSL when communicating with the broker
                           type: boolean
+                        userSecretRef:
+                          description: The kafka user name to use for authentication
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
                       required:
                         - uri
                       type: object
@@ -839,6 +1087,26 @@ spec:
                   type: integer
                 phase:
                   type: string
+                secrets:
+                  items:
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the secret name must be unique.
+                        type: string
+                      resourceVersion:
+                        type: string
+                      uid:
+                        description: |-
+                          UID is a type that holds unique ID values, including UUIDs.  Because we
+                          don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                          intent and helps make sure that UIDs and names do not get conflated.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
               type: object
               x-kubernetes-preserve-unknown-fields: true
           required:
@@ -1021,6 +1289,34 @@ spec:
                   description: Ceph Config options
                   nullable: true
                   type: object
+                cephConfigFromSecret:
+                  additionalProperties:
+                    additionalProperties:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                        - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: object
+                  description: CephConfigFromSecret works exactly like CephConfig but takes config value from Secret Key reference.
+                  nullable: true
+                  type: object
                 cephVersion:
                   description: The version information that instructs Rook to orchestrate a particular version of Ceph.
                   nullable: true
@@ -1176,11 +1472,7 @@ spec:
                       format: int64
                       type: integer
                     pgHealthCheckTimeout:
-                      description: |-
-                        PGHealthCheckTimeout is the time (in minutes) that the operator will wait for the placement groups to become
-                        healthy (active+clean) after a drain was completed and OSDs came back up. Rook will continue with the next drain
-                        if the timeout exceeds. It only works if managePodBudgets is true.
-                        No values or 0 means that the operator will wait until the placement groups are healthy before unblocking the next drain.
+                      description: 'DEPRECATED: PGHealthCheckTimeout is no longer implemented'
                       format: int64
                       type: integer
                     pgHealthyRegex:
@@ -1258,7 +1550,7 @@ spec:
                               alive or ready to receive traffic.
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
                                     description: |-
@@ -1279,7 +1571,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1297,7 +1589,7 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
                                     description: |-
@@ -1362,7 +1654,7 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving a TCP port.
+                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1406,7 +1698,7 @@ spec:
                               alive or ready to receive traffic.
                             properties:
                               exec:
-                                description: Exec specifies the action to take.
+                                description: Exec specifies a command to execute in the container.
                                 properties:
                                   command:
                                     description: |-
@@ -1427,7 +1719,7 @@ spec:
                                 format: int32
                                 type: integer
                               grpc:
-                                description: GRPC specifies an action involving a GRPC port.
+                                description: GRPC specifies a GRPC HealthCheckRequest.
                                 properties:
                                   port:
                                     description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1445,7 +1737,7 @@ spec:
                                   - port
                                 type: object
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
+                                description: HTTPGet specifies an HTTP GET request to perform.
                                 properties:
                                   host:
                                     description: |-
@@ -1510,7 +1802,7 @@ spec:
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: TCPSocket specifies an action involving a TCP port.
+                                description: TCPSocket specifies a connection to a TCP port.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1623,6 +1915,16 @@ spec:
                       maximum: 9
                       minimum: 0
                       type: integer
+                    externalMonIDs:
+                      description: |-
+                        ExternalMonIDs - optional list of monitor IDs which are deployed externally and not managed by Rook.
+                        If set, Rook will not remove mons with given IDs from quorum.
+                        This parameter is used only for local Rook cluster running in normal mode
+                        and will be ignored if external or stretched mode is used.
+                        leading
+                      items:
+                        type: string
+                      type: array
                     failureDomainLabel:
                       type: string
                     stretchCluster:
@@ -2566,7 +2868,7 @@ spec:
                         other network providers.
 
                         Valid keys are "public" and "cluster". Refer to Ceph networking documentation for more:
-                        https://docs.ceph.com/en/reef/rados/configuration/network-config-ref/
+                        https://docs.ceph.com/en/latest/rados/configuration/network-config-ref/
 
                         Refer to Multus network annotation documentation for help selecting values:
                         https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#run-pod-with-network-annotation
@@ -3279,6 +3581,16 @@ spec:
                       minimum: 0
                       nullable: true
                       type: number
+                    migration:
+                      description: Migration handles the OSD migration
+                      properties:
+                        confirmation:
+                          description: |-
+                            A user confirmation to migrate the OSDs. It destroys each OSD one at a time, cleans up the backing disk
+                            and prepares OSD with same ID on that disk
+                          pattern: ^$|^yes-really-migrate-osds$
+                          type: string
+                      type: object
                     nearFullRatio:
                       description: NearFullRatio is the ratio at which the cluster is considered nearly full and will raise a ceph health warning. Default is 0.85.
                       maximum: 1
@@ -5372,6 +5684,12 @@ spec:
                     osd:
                       description: OSDStatus represents OSD status of the ceph Cluster
                       properties:
+                        migrationStatus:
+                          description: MigrationStatus status represents the current status of any OSD migration.
+                          properties:
+                            pending:
+                              type: integer
+                          type: object
                         storeType:
                           additionalProperties:
                             type: integer
@@ -6822,7 +7140,11 @@ spec:
                             description: Enabled whether this pool is mirrored or not
                             type: boolean
                           mode:
-                            description: 'Mode is the mirroring mode: either pool or image'
+                            description: 'Mode is the mirroring mode: pool, image or init-only.'
+                            enum:
+                              - pool
+                              - image
+                              - init-only
                             type: string
                           peers:
                             description: Peers represents the peers spec
@@ -7006,7 +7328,11 @@ spec:
                           description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
+                          description: 'Mode is the mirroring mode: pool, image or init-only.'
+                          enum:
+                            - pool
+                            - image
+                            - init-only
                           type: string
                         peers:
                           description: Peers represents the peers spec
@@ -7161,7 +7487,7 @@ spec:
                             alive or ready to receive traffic.
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -7182,7 +7508,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7200,7 +7526,7 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -7265,7 +7591,7 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
+                              description: TCPSocket specifies a connection to a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -7881,7 +8207,7 @@ spec:
                             alive or ready to receive traffic.
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -7902,7 +8228,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7920,7 +8246,7 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -7985,7 +8311,7 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
+                              description: TCPSocket specifies a connection to a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -9643,7 +9969,7 @@ spec:
                             alive or ready to receive traffic.
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -9664,7 +9990,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -9682,7 +10008,7 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -9747,7 +10073,7 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
+                              description: TCPSocket specifies a connection to a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -10658,7 +10984,11 @@ spec:
                           description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
+                          description: 'Mode is the mirroring mode: pool, image or init-only.'
+                          enum:
+                            - pool
+                            - image
+                            - init-only
                           type: string
                         peers:
                           description: Peers represents the peers spec
@@ -11101,6 +11431,70 @@ spec:
                       nullable: true
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    opsLogSidecar:
+                      description: Enable enhanced operation Logs for S3 in a sidecar named ops-log
+                      nullable: true
+                      properties:
+                        resources:
+                          description: Resources represents the way to specify resource requirements for the ops-log sidecar
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                      type: object
                     placement:
                       nullable: true
                       properties:
@@ -11619,6 +12013,25 @@ spec:
                     priorityClassName:
                       description: PriorityClassName sets priority classes on the rgw pods
                       type: string
+                    readAffinity:
+                      description: |-
+                        ReadAffinity defines the RGW read affinity policy to optimize the read requests for the RGW clients
+                        Note: Only supported from Ceph Tentacle (v20)
+                      properties:
+                        type:
+                          description: |-
+                            Type defines the RGW ReadAffinity type
+                            localize: read from the nearest OSD based on crush location of the RGW client
+                            balance: picks a random OSD from the PG's active set
+                            default: read from the primary OSD
+                          enum:
+                            - localize
+                            - balance
+                            - default
+                          type: string
+                      required:
+                        - type
+                      type: object
                     resources:
                       description: The resource requirements for the rgw pods
                       nullable: true
@@ -11680,6 +12093,56 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    rgwCommandFlags:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        RgwCommandFlags sets Ceph RGW config values for the gateway clients that serve this object
+                        store. Values are modified at RGW startup, resulting in RGW pod restarts.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
+                    rgwConfig:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        RgwConfig sets Ceph RGW config values for the gateway clients that serve this object store.
+                        Values are modified at runtime without RGW restart.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
+                    rgwConfigFromSecret:
+                      additionalProperties:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      description: |-
+                        RgwConfigFromSecret works exactly like RgwConfig but takes config value from Secret Key reference.
+                        Values are modified at runtime without RGW restart.
+                        This feature is intended for advanced users. It allows breaking configurations to be easily
+                        applied. Use with caution.
+                      nullable: true
+                      type: object
                     securePort:
                       description: The port the rgw service will be listening on (https)
                       format: int32
@@ -11721,7 +12184,7 @@ spec:
                             alive or ready to receive traffic.
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -11742,7 +12205,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -11760,7 +12223,7 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -11825,7 +12288,7 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
+                              description: TCPSocket specifies a connection to a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -11867,7 +12330,7 @@ spec:
                             alive or ready to receive traffic.
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -11888,7 +12351,7 @@ spec:
                               format: int32
                               type: integer
                             grpc:
-                              description: GRPC specifies an action involving a GRPC port.
+                              description: GRPC specifies a GRPC HealthCheckRequest.
                               properties:
                                 port:
                                   description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -11906,7 +12369,7 @@ spec:
                                 - port
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -11971,7 +12434,7 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: TCPSocket specifies an action involving a TCP port.
+                              description: TCPSocket specifies a connection to a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -12050,7 +12513,6 @@ spec:
                         If the DNS name corresponds to an endpoint with DNS wildcard support, do not include the
                         wildcard itself in the list of hostnames.
                         E.g., use "mystore.example.com" instead of "*.mystore.example.com".
-                        The feature is supported only for Ceph v18 and later versions.
                       items:
                         type: string
                       type: array
@@ -12122,7 +12584,11 @@ spec:
                           description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
+                          description: 'Mode is the mirroring mode: pool, image or init-only.'
+                          enum:
+                            - pool
+                            - image
+                            - init-only
                           type: string
                         peers:
                           description: Peers represents the peers spec
@@ -12240,6 +12706,25 @@ spec:
                 protocols:
                   description: The protocol specification
                   properties:
+                    enableAPIs:
+                      description: |-
+                        Represents RGW 'rgw_enable_apis' config option. See: https://docs.ceph.com/en/reef/radosgw/config-ref/#confval-rgw_enable_apis
+                        If no value provided then all APIs will be enabled: s3, s3website, swift, swift_auth, admin, sts, iam, notifications
+                        If enabled APIs are set, all remaining APIs will be disabled.
+                        This option overrides S3.Enabled value.
+                      items:
+                        enum:
+                          - s3
+                          - s3website
+                          - swift
+                          - swift_auth
+                          - admin
+                          - sts
+                          - iam
+                          - notifications
+                        type: string
+                      nullable: true
+                      type: array
                     s3:
                       description: The spec for S3
                       nullable: true
@@ -12249,7 +12734,9 @@ spec:
                           nullable: true
                           type: boolean
                         enabled:
-                          description: Whether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility – by default S3 is enabled.
+                          description: |-
+                            Deprecated: use protocol.enableAPIs instead.
+                            Whether to enable S3. This defaults to true (even if protocols.s3 is not present in the CRD). This maintains backwards compatibility – by default S3 is enabled.
                           nullable: true
                           type: boolean
                       type: object
@@ -12411,7 +12898,7 @@ spec:
                   nullable: true
                   properties:
                     name:
-                      description: RGW Zone the Object Store is in
+                      description: CephObjectStoreZone name this CephObjectStore is part of
                       type: string
                   required:
                     - name
@@ -12535,7 +13022,7 @@ spec:
                   nullable: true
                   properties:
                     amz-cache:
-                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/quincy/radosgw/rgw-cache/#cache-api
+                      description: Add capabilities for user to send request to RGW Cache API header. Documented in https://docs.ceph.com/en/latest/radosgw/rgw-cache/#cache-api
                       enum:
                         - '*'
                         - read
@@ -12669,6 +13156,61 @@ spec:
                 displayName:
                   description: The display name for the ceph users
                   type: string
+                keys:
+                  description: |-
+                    Allows specifying credentials for the user. If not provided, the operator
+                    will generate them.
+                  items:
+                    description: |-
+                      ObjectUserKey defines a set of rgw user access credentials to be retrieved
+                      from secret resources.
+                    properties:
+                      accessKeyRef:
+                        description: Secret key selector for the access_key (commonly referred to as AWS_ACCESS_KEY_ID).
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      secretKeyRef:
+                        description: Secret key selector for the secret_key (commonly referred to as AWS_SECRET_ACCESS_KEY).
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must be a valid secret key.
+                            type: string
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must be defined
+                            type: boolean
+                        required:
+                          - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  type: array
                 quotas:
                   description: ObjectUserQuotaSpec can be used to set quotas for the object store user to limit their usage. See the [Ceph docs](https://docs.ceph.com/en/latest/radosgw/admin/?#quota-management) for more
                   nullable: true
@@ -12705,6 +13247,27 @@ spec:
                     type: string
                   nullable: true
                   type: object
+                keys:
+                  items:
+                    properties:
+                      name:
+                        description: name is unique within a namespace to reference a secret resource.
+                        type: string
+                      namespace:
+                        description: namespace defines the space within which the secret name must be unique.
+                        type: string
+                      resourceVersion:
+                        type: string
+                      uid:
+                        description: |-
+                          UID is a type that holds unique ID values, including UUIDs.  Because we
+                          don't ONLY use UUIDs, this is an alias to string.  Being a type captures
+                          intent and helps make sure that UIDs and names do not get conflated.
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  nullable: true
+                  type: array
                 observedGeneration:
                   description: ObservedGeneration is the latest generation observed by the controller.
                   format: int64
@@ -12947,7 +13510,11 @@ spec:
                           description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
+                          description: 'Mode is the mirroring mode: pool, image or init-only.'
+                          enum:
+                            - pool
+                            - image
+                            - init-only
                           type: string
                         peers:
                           description: Peers represents the peers spec
@@ -13126,7 +13693,11 @@ spec:
                           description: Enabled whether this pool is mirrored or not
                           type: boolean
                         mode:
-                          description: 'Mode is the mirroring mode: either pool or image'
+                          description: 'Mode is the mirroring mode: pool, image or init-only.'
+                          enum:
+                            - pool
+                            - image
+                            - init-only
                           type: string
                         peers:
                           description: Peers represents the peers spec

--- a/katalog/rook-operator/kustomization.yaml
+++ b/katalog/rook-operator/kustomization.yaml
@@ -11,10 +11,10 @@ namespace: rook-ceph
 images:
   - name: docker.io/rook/ceph
     newName: registry.sighup.io/fury/rook/ceph
-    newTag: v1.15.9
+    newTag: v1.17.2
   - name: quay.io/ceph/ceph
     newName: registry.sighup.io/fury/ceph/ceph
-    newTag: v17.2.5
+    newTag: v19.2.2
 
 patchesStrategicMerge:
   - patches/rook-ceph-operator-config-csi-images.yml

--- a/katalog/rook-operator/operator.yaml
+++ b/katalog/rook-operator/operator.yaml
@@ -55,11 +55,6 @@ data:
   # there is significant drop in read/write performance.
   # CSI_ENABLE_HOST_NETWORK: "true"
 
-  # Deprecation note: Rook uses "holder" pods to allow CSI to connect to the multus public network
-  # without needing hosts to the network. Holder pods are being removed. See issue for details:
-  # https://github.com/rook/rook/issues/13055. New Rook deployments should set this to "true".
-  CSI_DISABLE_HOLDER_PODS: "true"
-
   # Set to true to enable adding volume metadata on the CephFS subvolume and RBD images.
   # Not all users might be interested in getting volume/snapshot details as metadata on CephFS subvolume and RBD images.
   # Hence enable metadata is false by default.
@@ -128,12 +123,12 @@ data:
   # The default version of CSI supported by Rook will be started. To change the version
   # of the CSI driver to something other than what is officially supported, change
   # these images to the desired release of the CSI driver.
-  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.12.3"
-  # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.11.1"
-  # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.11.1"
-  # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v5.0.1"
-  # ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1"
-  # ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.6.1"
+  # ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.14.0"
+  # ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0"
+  # ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.13.1"
+  # ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v5.1.0"
+  # ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0"
+  # ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.8.0"
 
   # To indicate the image pull policy to be applied to all the containers in the csi driver pods.
   # ROOK_CSI_IMAGE_PULL_POLICY: "IfNotPresent"
@@ -479,7 +474,12 @@ data:
   # CSI_CEPHFS_LIVENESS_METRICS_PORT: "9081"
   # Configure CSI RBD liveness metrics port
   # CSI_RBD_LIVENESS_METRICS_PORT: "9080"
+
+  # We can override the ports for each individual component that uses the CSIADDONS sidecar
+  # This is useful if we're running in hostNetwork, where ports may conflict on the same host
   # CSIADDONS_PORT: "9070"
+  # CSIADDONS_RBD_PROVISIONER_PORT: "9070"
+  # CSIADDONS_CEPHFS_PROVISIONER_PORT: "9070"
 
   # Set CephFS Kernel mount options to use https://docs.ceph.com/en/latest/man/8/mount.ceph/#options
   # Set to "ms_mode=secure" when connections.encrypted is enabled in CephCluster CR
@@ -500,6 +500,12 @@ data:
   # Custom prefix value for the OBC provisioner instead of ceph cluster namespace, do not set on existing cluster
   # ROOK_OBC_PROVISIONER_NAME_PREFIX: "custom-prefix"
 
+  # Many OBC additional config fields may be risky for administrators to allow users control over.
+  # The safe and default-allowed fields are 'maxObjects' and 'maxSize'.
+  # Other fields should be considered risky. To allow all additional configs, use this value:
+  #   "maxObjects,maxSize,bucketMaxObjects,bucketMaxSize,bucketPolicy,bucketLifecycle,bucketOwner"
+  # ROOK_OBC_ALLOW_ADDITIONAL_CONFIG_FIELDS: "maxObjects,maxSize" # default allowed configs
+
   # Whether to start the discovery daemon to watch for raw storage devices on nodes in the cluster.
   # This daemon does not need to run if you are only going to create your OSDs based on StorageClassDeviceSets with PVCs.
   ROOK_ENABLE_DISCOVERY_DAEMON: "false"
@@ -509,7 +515,7 @@ data:
   CSI_ENABLE_CSIADDONS: "false"
   # Enable watch for faster recovery from rbd rwo node loss
   ROOK_WATCH_FOR_NODE_FAILURE: "true"
-  # ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.9.1"
+  # ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.12.0"
   # The CSI GRPC timeout value (in seconds). It should be >= 120. If this variable is not set or is an invalid value, it's default to 150.
   CSI_GRPC_TIMEOUT_SECONDS: "150"
 
@@ -575,6 +581,9 @@ data:
 
   # RevisionHistoryLimit value for all deployments created by rook.
   # ROOK_REVISION_HISTORY_LIMIT: "3"
+
+  #  Custom label to identify node hostname. If not set `kubernetes.io/hostname` will be used
+  ROOK_CUSTOM_HOSTNAME_LABEL: ""
 ---
 # OLM: BEGIN OPERATOR DEPLOYMENT
 apiVersion: apps/v1
@@ -609,7 +618,7 @@ spec:
       serviceAccountName: rook-ceph-system
       containers:
         - name: rook-ceph-operator
-          image: docker.io/rook/ceph:v1.15.9
+          image: docker.io/rook/ceph:v1.17.2
           args: ["ceph", "operator"]
           securityContext:
             runAsNonRoot: true
@@ -682,8 +691,9 @@ spec:
           #- name: LIB_BUCKET_PROVISIONER_THREADS
           #  value: "5"
 
-      # Uncomment it to run rook operator on the host network
-      #hostNetwork: true
+      # Uncomment these two settings to run the operator on the host network
+      # hostNetwork: true
+      # dnsPolicy: ClusterFirstWithHostNet
       volumes:
         - name: rook-config
           emptyDir: {}

--- a/katalog/rook-operator/patches/rook-ceph-operator-config-csi-images.yml
+++ b/katalog/rook-operator/patches/rook-ceph-operator-config-csi-images.yml
@@ -9,10 +9,10 @@ metadata:
   name: rook-ceph-operator-config
   namespace: rook-ceph
 data:
-  ROOK_CSI_CEPH_IMAGE: "registry.sighup.io/fury/cephcsi/cephcsi:v3.12.3"
-  ROOK_CSI_REGISTRAR_IMAGE: "registry.sighup.io/fury/sig-storage/csi-node-driver-registrar:v2.11.1"
-  ROOK_CSI_PROVISIONER_IMAGE: "registry.sighup.io/fury/sig-storage/csi-provisioner:v5.0.1"
-  ROOK_CSI_ATTACHER_IMAGE: "registry.sighup.io/fury/sig-storage/csi-attacher:v4.6.1"
-  ROOK_CSI_RESIZER_IMAGE: "registry.sighup.io/fury/sig-storage/csi-resizer:v1.11.1"
-  ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.sighup.io/fury/sig-storage/csi-snapshotter:v8.0.1"
-  ROOK_CSIADDONS_IMAGE: "registry.sighup.io/fury/csiaddons/k8s-sidecar:v0.9.1"
+  ROOK_CSI_CEPH_IMAGE: "quay.io/cephcsi/cephcsi:v3.14.0"
+  ROOK_CSI_REGISTRAR_IMAGE: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0"
+  ROOK_CSI_PROVISIONER_IMAGE: "registry.k8s.io/sig-storage/csi-provisioner:v5.2.0"
+  ROOK_CSI_ATTACHER_IMAGE: "registry.k8s.io/sig-storage/csi-attacher:v4.8.1"
+  ROOK_CSI_RESIZER_IMAGE: "registry.k8s.io/sig-storage/csi-resizer:v1.13.2"
+  ROOK_CSI_SNAPSHOTTER_IMAGE: "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1"
+  ROOK_CSIADDONS_IMAGE: "quay.io/csiaddons/k8s-sidecar:v0.12.0"


### PR DESCRIPTION
# `v0.4.0`

## Summary 💡

This release bumps rook version from `v1.15.9` to `v1.17.2`

## Description 📝

A lot of manifests have changed since we changed rook's version and most of the `yaml` are taken from their repo under the `example` folder. I have mostly aligned minor differences.

## Breaking Changes 💔

There are no breaking changes other than the fact that now the minimum required kubernetes version is 1.28

## Tests performed 🧪

- [ ] Tested an upgrade from the previous version 0.3.1 while running the monitoring and logging stack off of ceph, the upgrade was successful: the old data was kept and new data keeps coming in after the upgrade

## Future work 🔧

As stated in #3 E2E are missing from this add-on.